### PR TITLE
Clarify that Stop terminates all ongoing requests

### DIFF
--- a/xml/System.Net/HttpListener.xml
+++ b/xml/System.Net/HttpListener.xml
@@ -1164,7 +1164,7 @@ The following code example demonstrates calling the `Close` method:
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>Causes this instance to stop receiving incoming requests.</summary>
+        <summary>Causes this instance to stop receiving new incoming requests and terminates processing of all ongoing requests.</summary>
         <remarks>
           <format type="text/markdown"><![CDATA[  
   


### PR DESCRIPTION
Currently, the documentation says that HttpListener.Stop method causes it to stop receiving incoming requests. However, this statement is a bit misleading because it implies that processing of unfinished requests received before this call will be continued till the end. This is not correct because HttpListener.Stop immediately terminates processing of such requests.

